### PR TITLE
Addition an automaticallyVerticalDirection var and logic for it.

### DIFF
--- a/lib/super_tooltip.dart
+++ b/lib/super_tooltip.dart
@@ -148,6 +148,10 @@ class SuperTooltip {
   ///
   /// Enable background overlay
   final bool containsBackgroundOverlay;
+  
+  ///
+  /// The parameter chooses popupDirection automatically by axis Y
+  final bool automaticallyVerticalDirection;
 
   Offset? _targetCenter;
   OverlayEntry? _backGroundOverlay;
@@ -191,6 +195,7 @@ class SuperTooltip {
     this.dismissOnTapOutside = true,
     this.blockOutsidePointerEvents = true,
     this.containsBackgroundOverlay = true,
+    this.automaticallyVerticalDirection = false,
   })  : assert((maxWidth ?? double.infinity) >= (minWidth ?? 0.0)),
         assert((maxHeight ?? double.infinity) >= (minHeight ?? 0.0));
 
@@ -258,6 +263,14 @@ class SuperTooltip {
                   child: background,
                 ),
               ));
+    }
+    
+    if (automaticallyVerticalDirection) {
+      if (_targetCenter!.dy > overlay!.size.center(Offset.zero).dy) {
+        popupDirection = TooltipDirection.up;
+      } else {
+        popupDirection = TooltipDirection.down;
+      }
     }
 
     /// Handling snap far away feature.


### PR DESCRIPTION
I added automaticallyVerticalDirection var and some logic for it. If this var equals true, tooltip will be shown up (if the calling place is located below the center by axis Y) and tooltip will be shown down (if the calling place is located above the center by axis Y). 
This logic let to avoid some UI bugs and the similar logic is used on other widgets (dropdowns, popups, tooltips and etc).