### PR TITLE
Updated to support Flutter v3 null safety. Fixes WidgetsBinding error warning. 

### DIFF
--- a/lib/super_tooltip.dart
+++ b/lib/super_tooltip.dart
@@ -1092,7 +1092,7 @@ class _AnimationWrapperState extends State<_AnimationWrapper> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         setState(() {
           opacity = 1.0;


### PR DESCRIPTION
Fixes: [Flutter: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null](https://stackoverflow.com/questions/71289625/flutter-warning-operand-of-null-aware-operation-has-type-widgetsbinding)