### PR TITLE
Fixed flutter warning for null aware operation.

### DIFF
--- a/lib/super_tooltip.dart
+++ b/lib/super_tooltip.dart
@@ -1092,7 +1092,7 @@ class _AnimationWrapperState extends State<_AnimationWrapper> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    _ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((_) {
       if (mounted) {
         setState(() {
           opacity = 1.0;
@@ -1105,6 +1105,14 @@ class _AnimationWrapperState extends State<_AnimationWrapper> {
   Widget build(BuildContext context) {
     return widget.builder!(context, opacity);
   }
+
+  /// This allows a value of type T or T?
+  /// to be treated as a value of type T?.
+  ///
+  /// We use this so that APIs that have become
+  /// non-nullable can still be used with `!` and `?`
+  /// to support older versions of the API as well.
+  T? _ambiguate<T>(T? value) => value;
 }
 
 enum SuperTooltipDismissBehaviour { none, onTap, onPointerDown }


### PR DESCRIPTION
By wrapping the call WidgetBinding!.instance with a call to a method which accepts nullable variable and has a nullable type can add a support for the nullable operator.