### PR TITLE
Update super_tooltip_controller.dart

### DIFF
--- a/lib/src/super_tooltip_controller.dart
+++ b/lib/src/super_tooltip_controller.dart
@@ -6,7 +6,7 @@ import 'enums.dart';
 
 class SuperTooltipController extends ChangeNotifier {
   late Completer _completer;
-  bool _isVisible = true;
+  bool _isVisible = false;
   bool get isVisible => _isVisible;
 
   late Event event;


### PR DESCRIPTION
SuperTooltipController _isVisible is initialised to true, so once attached to a SuperToolTip, actual visibility and controller visibility will not match. Changed initial value for _isVisible so that they will match. 