### PR TITLE
fix: correct SuperTooltip controller parameter name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You have to make your Widget a `StatefulWidget` and you just need to create a co
   final _controller = SuperTooltipController();
 
   child: SuperTooltip(
-    _controller: tooltipController,
+    controller: _controller,
     // ...
     )
 
@@ -234,3 +234,4 @@ In case of trivial fixes open a [pull request](https://github.com/bensonarafat/s
 
 <!-- readme: contributors -start -->
 <!-- readme: contributors -end -->
+


### PR DESCRIPTION
This PR fixes an issue in the README where the usage example for `SuperTooltip` incorrectly uses `_controller:` as a parameter.
The correct parameter name in the widget is `controller`:.
Because of this mismatch, developers following the README example encounter errors.